### PR TITLE
feat: update make package flow

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+# The CODEOWNERS file is used to define individuals or teams that are
+# responsible for code in a repository. For details, please refer to
+# https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+
+# DevOps
+# todo: replace this with a group name
+* @franciscobo @pulpo

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ package:
 	helm dependency update charts/onechart
 	helm package charts/onechart
 	mv onechart*.tgz docs
-	# helm repo index docs --url https://chart.onechart.dev
+	helm repo index docs
 
 debug:
 	helm dependency update charts/onechart


### PR DESCRIPTION
## feat: Enable Helm repository indexing in Makefile

This PR enables the `helm repo index docs` command within the `package` target of the Makefile.

Previously, this command was commented out, preventing the automatic generation
or update of the `index.yaml` file in the `docs` directory, which is crucial for a functional Helm chart repository.

By uncommenting this line, the `index.yaml` file will now be automatically
generated when charts are packaged. The `--url` flag has been removed to
simplify the indexing process, leveraging default behavior suitable for the `docs` directory structure.
