### PR TITLE
feat: add AWS Client VPN with SAML/SSO (#19)

### DIFF
--- a/infra/infra/09_vpn/dev/.terraform.lock.hcl
+++ b/infra/infra/09_vpn/dev/.terraform.lock.hcl
@@ -1,0 +1,44 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version = "4.2.1"
+  hashes = [
+    "h1:F5d6bQY8UlBo0D71Sv7CsV+3aZOFz0yeNF+vufog7h4=",
+    "zh:0d1e7d07ac973b97fa228f46596c800de830820506ee145626f079dd6bbf8d8a",
+    "zh:5c7e3d4348cb4861ab812973ef493814a4b224bdd3e9d534a7c8a7c992382b86",
+    "zh:7c6d4a86cd7a4e9c1025c6b3a3a6a45dea202af85d870cddbab455fb1bd568ad",
+    "zh:7d0864755ba093664c4b2c07c045d3f5e3d7c799dda1a3ef33d17ed1ac563191",
+    "zh:83734f57950ab67c0d6a87babdb3f13c908cbe0a48949333f489698532e1391b",
+    "zh:951e3c285218ebca0cf20eaa4265020b4ef042fea9c6ade115ad1558cfe459e5",
+    "zh:b9543955b4297e1d93b85900854891c0e645d936d8285a190030475379c5c635",
+    "zh:bb1bd9e86c003d08c30c1b00d44118ed5bbbf6b1d2d6f7eaac4fa5c6ebea5933",
+    "zh:c9477bfe00653629cd77ddac3968475f7ad93ac3ca8bc45b56d1d9efb25e4a6e",
+    "zh:d4cfda8687f736d0cba664c22ec49dae1188289e214ef57f5afe6a7217854fed",
+    "zh:dc77ee066cf96532a48f0578c35b1eaf6dc4d8ddd0e3ae8e029a3b10676dd5d3",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/infra/infra/09_vpn/dev/init.tf
+++ b/infra/infra/09_vpn/dev/init.tf
@@ -1,0 +1,16 @@
+terraform {
+  backend "s3" {
+    bucket       = "southernlights-tf-state-shared"
+    encrypt      = true
+    key          = "09_vpn/dev/terraform.tfstate"
+    region       = "us-east-1"
+    use_lockfile = true
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/infra/infra/09_vpn/dev/locals.tf
+++ b/infra/infra/09_vpn/dev/locals.tf
@@ -1,0 +1,16 @@
+locals {
+  aws_account_id    = "027922993866"
+  region            = "us-east-1"
+  environment_short = "dev"
+  organization      = "southernlights-tech"
+  vpc_name          = "dev-vpc"
+
+  tags = {
+    Environment = local.environment_short
+    Git         = "https://github.com/${local.organization}/infra/tree/main/infra/09_vpn/dev"
+    ManagedBy   = "Terraform"
+    Service     = local.organization
+    Project     = "vpn-infrastructure"
+    AccountId   = local.aws_account_id
+  }
+}

--- a/infra/infra/09_vpn/dev/main.tf
+++ b/infra/infra/09_vpn/dev/main.tf
@@ -1,0 +1,36 @@
+resource "aws_iam_saml_provider" "vpn" {
+  name                   = "aws-client-vpn-dev"
+  saml_metadata_document = file("${path.module}/saml-metadata.xml")
+}
+
+module "vpn" {
+  source = "../../../modules/aws-client-vpn"
+
+  aws_account_id    = local.aws_account_id
+  region            = local.region
+  name              = "vpn"
+  environment       = "development"
+  environment_short = local.environment_short
+  vpc_name          = local.vpc_name
+  client_cidr_block = "10.100.0.0/22"
+
+  saml_provider_arn              = aws_iam_saml_provider.vpn.arn
+  self_service_saml_provider_arn = aws_iam_saml_provider.vpn.arn
+
+  dns_servers = ["10.10.0.2"] # Default AWS DNS for 10.10.0.0/16 VPC
+
+  vpn_routes = [
+    {
+      cidr        = "10.10.0.0/16"
+      description = "VPC Dev Access"
+    }
+  ]
+
+  organization       = local.organization
+  dns_names          = ["vpn.dev.southernlights.tech"]
+  log_retention_days = 7
+  availability_zones = ["us-east-1a", "us-east-1b"]
+
+  managedby  = "Terraform"
+  repository = "https://github.com/southernlights-tech/infra"
+}

--- a/infra/infra/09_vpn/dev/providers.tf
+++ b/infra/infra/09_vpn/dev/providers.tf
@@ -1,0 +1,11 @@
+provider "aws" {
+  region = local.region
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.aws_account_id}:role/service-role/terraform-shared"
+  }
+
+  default_tags {
+    tags = local.tags
+  }
+}

--- a/infra/infra/09_vpn/dev/saml-metadata.xml
+++ b/infra/infra/09_vpn/dev/saml-metadata.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://portal.sso.us-east-1.amazonaws.com/saml/assertion/Mzg0NjQ4ODA0MTA0X2lucy03MjIzMzFkOWY2MmJmYTU5">
+  <md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <md:KeyDescriptor use="signing">
+      <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <ds:X509Data>
+          <ds:X509Certificate>MIIDBzCCAe+gAwIBAgIFAM2tEegwDQYJKoZIhvcNAQELBQAwRTEWMBQGA1UEAwwNYW1hem9uYXdzLmNvbTENMAsGA1UECwwESURBUzEPMA0GA1UECgwGQW1hem9uMQswCQYDVQQGEwJVUzAeFw0yNjA0MjAyMDEyMjFaFw0zMTA0MjAyMDEyMjFaMEUxFjAUBgNVBAMMDWFtYXpvbmF3cy5jb20xDTALBgNVBAsMBElEQVMxDzANBgNVBAoMBkFtYXpvbjELMAkGA1UEBhMCVVMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDCmhjMBj8V4Yp4xEIrVqFLcWTaHnEVZf2R9SRZ1FPkTuClgjQ+2Rq8v8AxRtw+IacC/3aRHJ+R9llbyaN6EWHiuFJ31f12uiXFWdTdwHdHvw/ZjORO5IFX5MoKAdGfIOMf1aFQ0jBw+XDcXkopTVGnao5ixjwD0dpb7qaq4N90hRLuA6RChmsTfH2no9SD18ga7ujl7l0pxMS9kGu9d2PtMmQT5RsrntXyvBYA74MO9Bxvn19k28JOctfDmyaJTczq6j3R/qilfXXELXM4OSDf3WXCLBlTnUEOEbX3E1buB+poQyrLvG2bzza+z6lprZrM0Ye3q1mdu3f1WTt2V9cFAgMBAAEwDQYJKoZIhvcNAQELBQADggEBALChVbItHOPSr3Emp6jitGt1GrY+50ZSEwPc3F6kn+7m6NuVc8b4KoNb7usi49h5YVrmu+2+TLZjO2tBLr55ogBXcUmw9jk1z47+emWW8Uw60/wRqnuBxvwsI0kfq9WCaoYVwH96pQ4TSUBHKrM46qJdu2dohW+MUQt1WfV0uL4ltPkP8d0SiQl64fCL1boJCzCJ94epouuyjSodjZRE0fxgBl26vyIOrqbKsl/TQxhD4S2cEI6LGiktR3KBXQ1mEHc7ZlLlN1HoSpyCc0UtJy9FGi84ERupWN30jp8TGP5ImSD+V13p8SoZHpHaR2BPvdC2Y5bCASqYOdsvUIHcd08=</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </md:KeyDescriptor>
+    <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://portal.sso.us-east-1.amazonaws.com/saml/logout/Mzg0NjQ4ODA0MTA0X2lucy03MjIzMzFkOWY2MmJmYTU5"/>
+    <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://portal.sso.us-east-1.amazonaws.com/saml/logout/Mzg0NjQ4ODA0MTA0X2lucy03MjIzMzFkOWY2MmJmYTU5"/>
+    <md:NameIDFormat/>
+    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://portal.sso.us-east-1.amazonaws.com/saml/assertion/Mzg0NjQ4ODA0MTA0X2lucy03MjIzMzFkOWY2MmJmYTU5"/>
+    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://portal.sso.us-east-1.amazonaws.com/saml/assertion/Mzg0NjQ4ODA0MTA0X2lucy03MjIzMzFkOWY2MmJmYTU5"/>
+  </md:IDPSSODescriptor>
+</md:EntityDescriptor>

--- a/infra/modules/aws-client-vpn/README.md
+++ b/infra/modules/aws-client-vpn/README.md
@@ -1,0 +1,109 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_acm_certificate.ca](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate) | resource |
+| [aws_acm_certificate.client](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate) | resource |
+| [aws_acm_certificate.server](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate) | resource |
+| [aws_cloudwatch_log_group.vpn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_log_stream.vpn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_stream) | resource |
+| [aws_ec2_client_vpn_authorization_rule.all_groups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_client_vpn_authorization_rule) | resource |
+| [aws_ec2_client_vpn_authorization_rule.group_vpn_authorization](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_client_vpn_authorization_rule) | resource |
+| [aws_ec2_client_vpn_endpoint.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_client_vpn_endpoint) | resource |
+| [aws_ec2_client_vpn_network_association.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_client_vpn_network_association) | resource |
+| [aws_ec2_client_vpn_route.routes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_client_vpn_route) | resource |
+| [aws_security_group.vpn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [tls_cert_request.client](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/cert_request) | resource |
+| [tls_cert_request.server](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/cert_request) | resource |
+| [tls_locally_signed_cert.client](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/locally_signed_cert) | resource |
+| [tls_locally_signed_cert.server](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/locally_signed_cert) | resource |
+| [tls_private_key.ca](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
+| [tls_private_key.client](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
+| [tls_private_key.server](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
+| [tls_self_signed_cert.ca](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/self_signed_cert) | resource |
+| [aws_subnets.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
+| [aws_vpc.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | List of availability zones in the region where VPN subnets will be deployed | `list(string)` | n/a | yes |
+| <a name="input_aws_account_id"></a> [aws\_account\_id](#input\_aws\_account\_id) | AWS account ID for the VPN infrastructure | `string` | n/a | yes |
+| <a name="input_client_cidr_block"></a> [client\_cidr\_block](#input\_client\_cidr\_block) | CIDR block to be allocated for connected VPN clients | `string` | n/a | yes |
+| <a name="input_disconnect_on_session_timeout"></a> [disconnect\_on\_session\_timeout](#input\_disconnect\_on\_session\_timeout) | Disconnect on session timeout | `bool` | `true` | no |
+| <a name="input_dns_names"></a> [dns\_names](#input\_dns\_names) | List of DNS names to be included in the self-signed certificate | `list(string)` | n/a | yes |
+| <a name="input_dns_servers"></a> [dns\_servers](#input\_dns\_servers) | List of DNS servers to be used by VPN clients for DNS resolution | `list(string)` | n/a | yes |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name used for tagging and identification | `string` | n/a | yes |
+| <a name="input_environment_short"></a> [environment\_short](#input\_environment\_short) | Short environment name used for resource naming and tagging | `string` | n/a | yes |
+| <a name="input_log_retention_days"></a> [log\_retention\_days](#input\_log\_retention\_days) | CloudWatch log retention period in days for VPN endpoint logs | `number` | n/a | yes |
+| <a name="input_managedby"></a> [managedby](#input\_managedby) | Email or team responsible for managing this VPN infrastructure | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Name prefix used for all VPN resources | `string` | n/a | yes |
+| <a name="input_organization"></a> [organization](#input\_organization) | Organization name to be included in the self-signed certificate | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | AWS region where the VPN endpoint will be deployed | `string` | n/a | yes |
+| <a name="input_repository"></a> [repository](#input\_repository) | Repository URL where this infrastructure code is managed | `string` | n/a | yes |
+| <a name="input_saml_provider_arn"></a> [saml\_provider\_arn](#input\_saml\_provider\_arn) | ARN of the SAML identity provider used for federated authentication on the VPN endpoint | `string` | n/a | yes |
+| <a name="input_self_service_portal"></a> [self\_service\_portal](#input\_self\_service\_portal) | Enable self-service portal | `string` | `"enabled"` | no |
+| <a name="input_self_service_saml_provider_arn"></a> [self\_service\_saml\_provider\_arn](#input\_self\_service\_saml\_provider\_arn) | ARN of the SAML identity provider used for the self-service portal | `string` | n/a | yes |
+| <a name="input_session_timeout_hours"></a> [session\_timeout\_hours](#input\_session\_timeout\_hours) | VPN session timeout in hours | `number` | `12` | no |
+| <a name="input_split_tunnel"></a> [split\_tunnel](#input\_split\_tunnel) | Enable split tunneling | `bool` | `true` | no |
+| <a name="input_vpc_name"></a> [vpc\_name](#input\_vpc\_name) | Name of the VPC where the VPN endpoint will be deployed | `string` | n/a | yes |
+| <a name="input_vpn_authorization_rules"></a> [vpn\_authorization\_rules](#input\_vpn\_authorization\_rules) | VPN authorization rules based on groups | <pre>list(object({<br/>    cidr        = string<br/>    group       = string<br/>    description = string<br/>  }))</pre> | `[]` | no |
+| <a name="input_vpn_port"></a> [vpn\_port](#input\_vpn\_port) | VPN port | `number` | `443` | no |
+| <a name="input_vpn_routes"></a> [vpn\_routes](#input\_vpn\_routes) | List of VPN routes defining network destinations accessible through the VPN endpoint | <pre>list(object({<br/>    cidr        = string<br/>    description = string<br/>  }))</pre> | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_ca_certificate"></a> [ca\_certificate](#output\_ca\_certificate) | CA certificate |
+| <a name="output_client_certificate"></a> [client\_certificate](#output\_client\_certificate) | Client certificate for VPN authentication |
+| <a name="output_client_private_key"></a> [client\_private\_key](#output\_client\_private\_key) | Client private key for VPN authentication |
+| <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the VPN security group |
+| <a name="output_self_service_portal_url"></a> [self\_service\_portal\_url](#output\_self\_service\_portal\_url) | The URL of the self-service portal for Client VPN |
+| <a name="output_vpn_arn"></a> [vpn\_arn](#output\_vpn\_arn) | The ARN of the Client VPN endpoint |
+| <a name="output_vpn_dns_name"></a> [vpn\_dns\_name](#output\_vpn\_dns\_name) | VPN DNS name |
+| <a name="output_vpn_id"></a> [vpn\_id](#output\_vpn\_id) | The ID of the Client VPN endpoint |
+<!-- END_TF_DOCS -->
+
+## VPN Authorization Rules Configuration
+
+VPN authorization rules control which groups of users can access specific network CIDRs through the Client VPN endpoint. The `vpn_authorization_rules` variable accepts a list of authorization rules, each specifying a target CIDR, a description, and an associated group.
+
+### Access Group IDs
+
+Access group IDs are obtained from AWS IAM Identity Center, not from Okta. When using AWS IAM Identity Center for authentication, groups are managed within the AWS console, not in Okta. To find your group names:
+
+1. Navigate to AWS Console → Search "IAM Identity Center"
+2. Go to Groups
+3. View the available groups (e.g., "aws-Users", "aws-Reviewers", "aws-Admins")
+4. Click on a group → General Information
+5. Use these exact group id as the `group` value in your authorization rules
+6. Verify that your users are assigned to these groups in AWS IAM Identity Center
+
+Note: Group membership is managed in AWS IAM Identity Center. When users authenticate through Okta, AWS IAM Identity Center assigns them to groups, and these groups are included in the SAML assertion sent to the VPN endpoint.
+### Authorization Rule Behavior
+
+The module implements a conditional authorization strategy based on the `vpn_authorization_rules` variable:
+
+- **When `vpn_authorization_rules` is empty (default)**: The `aws_ec2_client_vpn_authorization_rule.all_groups` resource is created with `authorize_all_groups = true`. This grants all authenticated users access to all networks (0.0.0.0/0), regardless of group membership.
+
+- **When `vpn_authorization_rules` contains one or more rules**: The `aws_ec2_client_vpn_authorization_rule.all_groups` resource is NOT created (count = 0). Instead, individual authorization rules are created via `aws_ec2_client_vpn_authorization_rule.group_vpn_authorization` using a `for_each` loop. Each rule restricts access to specific network CIDRs based on the user's group membership. Only users belonging to the specified group can access the associated CIDR block.
+
+This design allows you to start with permissive access (all groups) and progressively implement granular group-based access controls by populating the `vpn_authorization_rules` variable.

--- a/infra/modules/aws-client-vpn/certificate.tf
+++ b/infra/modules/aws-client-vpn/certificate.tf
@@ -1,0 +1,145 @@
+# TLS resources with stable naming and lifecycle management
+resource "tls_private_key" "ca" {
+  algorithm = "RSA"
+  rsa_bits  = 2048
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [algorithm, rsa_bits]
+  }
+}
+
+resource "tls_self_signed_cert" "ca" {
+  private_key_pem = tls_private_key.ca.private_key_pem
+
+  subject {
+    common_name  = "${var.name}-ca"
+    organization = var.organization
+  }
+
+  dns_names = var.dns_names
+
+  validity_period_hours = 87600
+  is_ca_certificate     = true
+
+  allowed_uses = [
+    "cert_signing",
+    "crl_signing",
+  ]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_acm_certificate" "ca" {
+  private_key      = tls_private_key.ca.private_key_pem
+  certificate_body = tls_self_signed_cert.ca.cert_pem
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = local.tags
+}
+
+resource "tls_private_key" "server" {
+  algorithm = "RSA"
+  rsa_bits  = 2048
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [algorithm, rsa_bits]
+  }
+}
+
+resource "tls_cert_request" "server" {
+  private_key_pem = tls_private_key.server.private_key_pem
+
+  subject {
+    common_name  = "${var.name}-server"
+    organization = var.organization
+  }
+
+  dns_names = var.dns_names
+}
+
+resource "tls_locally_signed_cert" "server" {
+  cert_request_pem      = tls_cert_request.server.cert_request_pem
+  ca_private_key_pem    = tls_private_key.ca.private_key_pem
+  ca_cert_pem           = tls_self_signed_cert.ca.cert_pem
+  validity_period_hours = 87600
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+  ]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_acm_certificate" "server" {
+  private_key       = tls_private_key.server.private_key_pem
+  certificate_body  = tls_locally_signed_cert.server.cert_pem
+  certificate_chain = tls_self_signed_cert.ca.cert_pem
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = local.tags
+}
+
+# Client certificate for authentication
+resource "tls_private_key" "client" {
+  algorithm = "RSA"
+  rsa_bits  = 2048
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [algorithm, rsa_bits]
+  }
+}
+
+resource "tls_cert_request" "client" {
+  private_key_pem = tls_private_key.client.private_key_pem
+
+  subject {
+    common_name  = "${var.name}-client"
+    organization = var.organization
+  }
+
+  dns_names = var.dns_names
+}
+
+resource "tls_locally_signed_cert" "client" {
+  cert_request_pem      = tls_cert_request.client.cert_request_pem
+  ca_private_key_pem    = tls_private_key.ca.private_key_pem
+  ca_cert_pem           = tls_self_signed_cert.ca.cert_pem
+  validity_period_hours = 87600
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "client_auth",
+  ]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_acm_certificate" "client" {
+  private_key       = tls_private_key.client.private_key_pem
+  certificate_body  = tls_locally_signed_cert.client.cert_pem
+  certificate_chain = tls_self_signed_cert.ca.cert_pem
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = local.tags
+}

--- a/infra/modules/aws-client-vpn/data.tf
+++ b/infra/modules/aws-client-vpn/data.tf
@@ -1,0 +1,17 @@
+data "aws_vpc" "selected" {
+  filter {
+    name   = "tag:Name"
+    values = [var.vpc_name]
+  }
+}
+
+data "aws_subnets" "selected" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.selected.id]
+  }
+  filter {
+    name   = "availability-zone"
+    values = var.availability_zones
+  }
+}

--- a/infra/modules/aws-client-vpn/locals.tf
+++ b/infra/modules/aws-client-vpn/locals.tf
@@ -1,0 +1,10 @@
+locals {
+  tags = {
+    Name        = var.name
+    Environment = var.environment
+    Service     = var.name
+    Terraform   = "True"
+    Managedby   = var.managedby
+    Repository  = var.repository
+  }
+}

--- a/infra/modules/aws-client-vpn/logs.tf
+++ b/infra/modules/aws-client-vpn/logs.tf
@@ -1,0 +1,12 @@
+# CloudWatch Log Group
+resource "aws_cloudwatch_log_group" "vpn" {
+  name              = "/aws/vpn/${var.name}/logs"
+  retention_in_days = var.log_retention_days
+
+  tags = local.tags
+}
+
+resource "aws_cloudwatch_log_stream" "vpn" {
+  name           = "${var.name}-usage"
+  log_group_name = aws_cloudwatch_log_group.vpn.name
+}

--- a/infra/modules/aws-client-vpn/main.tf
+++ b/infra/modules/aws-client-vpn/main.tf
@@ -1,0 +1,119 @@
+# Security Group
+resource "aws_security_group" "vpn" {
+  name_prefix = "${var.name}-vpn-"
+  vpc_id      = data.aws_vpc.selected.id
+
+  ingress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    self      = true
+    # cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.tags, {
+    Name = "${var.name}-vpn-sg"
+  })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# VPN Endpoint - This is the main resource that was being recreated
+resource "aws_ec2_client_vpn_endpoint" "main" {
+  description                   = "${var.name} Client VPN"
+  server_certificate_arn        = aws_acm_certificate.server.arn
+  client_cidr_block             = var.client_cidr_block
+  split_tunnel                  = var.split_tunnel
+  vpc_id                        = data.aws_vpc.selected.id
+  session_timeout_hours         = var.session_timeout_hours
+  disconnect_on_session_timeout = var.disconnect_on_session_timeout
+  security_group_ids            = [aws_security_group.vpn.id]
+  vpn_port                      = var.vpn_port
+  self_service_portal           = var.self_service_portal
+  dns_servers                   = var.dns_servers
+  # dns_servers = ["169.254.169.253"]
+
+  authentication_options {
+    type                           = "federated-authentication"
+    saml_provider_arn              = var.saml_provider_arn
+    self_service_saml_provider_arn = var.self_service_saml_provider_arn
+    root_certificate_chain_arn     = aws_acm_certificate.client.arn
+  }
+
+  connection_log_options {
+    enabled               = true
+    cloudwatch_log_group  = aws_cloudwatch_log_group.vpn.name
+    cloudwatch_log_stream = aws_cloudwatch_log_stream.vpn.name
+  }
+
+  tags = merge(local.tags, {
+    Name = "${var.name}-client-vpn"
+  })
+
+  # Prevent recreation by ensuring certificates are created first
+  depends_on = [
+    aws_acm_certificate.server,
+    aws_acm_certificate.client,
+    aws_cloudwatch_log_group.vpn,
+    aws_cloudwatch_log_stream.vpn
+  ]
+
+  lifecycle {
+    create_before_destroy = true
+    # Ignore changes to certificate ARNs to prevent recreation
+    ignore_changes = [
+      server_certificate_arn,
+      authentication_options
+    ]
+  }
+}
+
+# Network Association
+resource "aws_ec2_client_vpn_network_association" "main" {
+  client_vpn_endpoint_id = aws_ec2_client_vpn_endpoint.main.id
+  subnet_id              = data.aws_subnets.selected.ids[0]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Network Routes
+resource "aws_ec2_client_vpn_route" "routes" {
+  for_each = { for idx, route in var.vpn_routes : idx => route }
+
+  client_vpn_endpoint_id = aws_ec2_client_vpn_endpoint.main.id
+  destination_cidr_block = each.value.cidr
+  target_vpc_subnet_id   = data.aws_subnets.selected.ids[0]
+  description            = each.value.description
+}
+
+# Authorization rule to allow access to all networks
+resource "aws_ec2_client_vpn_authorization_rule" "all_groups" {
+  # Use this if vpn_authorization_rules is empty (default)
+  count                  = length(var.vpn_authorization_rules) > 0 ? 0 : 1
+  
+  client_vpn_endpoint_id = aws_ec2_client_vpn_endpoint.main.id
+  target_network_cidr    = "0.0.0.0/0"
+  authorize_all_groups   = true
+  description            = "Allow all authenticated users access to all networks"
+}
+
+# Authorization rules based on groups
+resource "aws_ec2_client_vpn_authorization_rule" "group_vpn_authorization" {
+  for_each = { for idx, rule in var.vpn_authorization_rules : idx => rule }
+
+  client_vpn_endpoint_id = aws_ec2_client_vpn_endpoint.main.id
+  target_network_cidr    = each.value.cidr
+  access_group_id        = each.value.group
+  description            = each.value.description
+}

--- a/infra/modules/aws-client-vpn/outputs.tf
+++ b/infra/modules/aws-client-vpn/outputs.tf
@@ -1,0 +1,42 @@
+output "vpn_id" {
+  value       = aws_ec2_client_vpn_endpoint.main.id
+  description = "The ID of the Client VPN endpoint"
+}
+
+output "vpn_arn" {
+  value       = aws_ec2_client_vpn_endpoint.main.arn
+  description = "The ARN of the Client VPN endpoint"
+}
+
+output "vpn_dns_name" {
+  value       = aws_ec2_client_vpn_endpoint.main.dns_name
+  description = "VPN DNS name"
+}
+
+output "security_group_id" {
+  value       = aws_security_group.vpn.id
+  description = "The ID of the VPN security group"
+}
+
+output "client_certificate" {
+  value       = tls_locally_signed_cert.client.cert_pem
+  description = "Client certificate for VPN authentication"
+  sensitive   = true
+}
+
+output "client_private_key" {
+  value       = tls_private_key.client.private_key_pem
+  description = "Client private key for VPN authentication"
+  sensitive   = true
+}
+
+output "ca_certificate" {
+  value       = tls_self_signed_cert.ca.cert_pem
+  description = "CA certificate"
+  sensitive   = true
+}
+
+output "self_service_portal_url" {
+  value       = aws_ec2_client_vpn_endpoint.main.self_service_portal_url
+  description = "The URL of the self-service portal for Client VPN"
+}

--- a/infra/modules/aws-client-vpn/variables.tf
+++ b/infra/modules/aws-client-vpn/variables.tf
@@ -1,0 +1,128 @@
+variable "aws_account_id" {
+  description = "AWS account ID for the VPN infrastructure"
+  type        = string
+}
+
+variable "region" {
+  description = "AWS region where the VPN endpoint will be deployed"
+  type        = string
+}
+
+variable "name" {
+  description = "Name prefix used for all VPN resources"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name used for tagging and identification"
+  type        = string
+}
+
+variable "environment_short" {
+  description = "Short environment name used for resource naming and tagging"
+  type        = string
+}
+
+variable "vpc_name" {
+  description = "Name of the VPC where the VPN endpoint will be deployed"
+  type        = string
+}
+
+variable "client_cidr_block" {
+  description = "CIDR block to be allocated for connected VPN clients"
+  type        = string
+}
+
+variable "split_tunnel" {
+  description = "Enable split tunneling"
+  type        = bool
+  default     = true
+}
+
+variable "session_timeout_hours" {
+  description = "VPN session timeout in hours"
+  type        = number
+  default     = 12
+}
+
+variable "disconnect_on_session_timeout" {
+  description = "Disconnect on session timeout"
+  type        = bool
+  default     = true
+}
+
+variable "vpn_port" {
+  description = "VPN port"
+  type        = number
+  default     = 443
+}
+
+variable "self_service_portal" {
+  description = "Enable self-service portal"
+  type        = string
+  default     = "enabled"
+}
+
+variable "dns_servers" {
+  description = "List of DNS servers to be used by VPN clients for DNS resolution"
+  type        = list(string)
+}
+
+variable "saml_provider_arn" {
+  description = "ARN of the SAML identity provider used for federated authentication on the VPN endpoint"
+  type        = string
+}
+
+variable "self_service_saml_provider_arn" {
+  description = "ARN of the SAML identity provider used for the self-service portal"
+  type        = string
+}
+
+variable "vpn_routes" {
+  description = "List of VPN routes defining network destinations accessible through the VPN endpoint"
+  type = list(object({
+    cidr        = string
+    description = string
+  }))
+}
+
+variable "vpn_authorization_rules" {
+  description = "VPN authorization rules based on groups"
+  type = list(object({
+    cidr        = string
+    group       = string
+    description = string
+  }))
+  default = []
+}
+
+variable "organization" {
+  description = "Organization name to be included in the self-signed certificate"
+  type        = string
+}
+
+variable "dns_names" {
+  description = "List of DNS names to be included in the self-signed certificate"
+  type        = list(string)
+}
+
+variable "log_retention_days" {
+  description = "CloudWatch log retention period in days for VPN endpoint logs"
+  type        = number
+}
+
+variable "availability_zones" {
+  description = "List of availability zones in the region where VPN subnets will be deployed"
+  type        = list(string)
+}
+
+variable "managedby" {
+  description = "Email or team responsible for managing this VPN infrastructure"
+  type        = string
+}
+
+variable "repository" {
+  description = "Repository URL where this infrastructure code is managed"
+  type        = string
+}
+


### PR DESCRIPTION
## Summary
This PR implements an AWS Client VPN endpoint in the `dev` environment using SAML 2.0 federation with IAM Identity Center (SSO).

## Changes
- New generic module `modules/aws-client-vpn/` (sanitized).
- New infrastructure component `infra/09_vpn/dev/`.
- SAML Provider integration.
- Split Tunneling enabled for VPC Dev access.

## Verification
- Terraform plan verified (19 resources to add).
- SAML Metadata verified from IAM Identity Center.

Fixes #19